### PR TITLE
Privacity protection on logging

### DIFF
--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -23,7 +23,7 @@ module GrapeLogging
       def parameters(request, response)
         {
             path: request.path,
-            params: request.params.to_hash,
+            params: obfuscate_parameters(request.params),
             method: request.request_method,
             total: total_runtime,
             db: @db_duration.round(2),
@@ -50,6 +50,18 @@ module GrapeLogging
 
       def stop_time
         @stop_time ||= Time.now
+      end
+
+      def obfuscate_parameters(request_parameters)
+        filtered_parameters = request_parameters.clone.to_hash
+        sensitive_parameters.each do |param|
+          filtered_parameters[param.to_s] = '***'
+        end
+        filtered_parameters
+      end
+
+      def sensitive_parameters
+        defined?(Rails.application) ? Rails.application.config.filter_parameters : []
       end
     end
   end


### PR DESCRIPTION
This code allows the declaration of special fields (such as passwords) to be obfuscatd from the logging.
Here is an usage example:

``` ruby
use GrapeLogging::Middleware::RequestLogger, { logger: logger, obfuscated_params: ['password'] }
```