### PR TITLE
Fix serious memory leak

### DIFF
--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -7,7 +7,7 @@ module GrapeLogging
         start_time
 
         @db_duration = 0
-        ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+        @subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
           event = ActiveSupport::Notifications::Event.new(*args)
           @db_duration += event.duration
         end if defined?(ActiveRecord)
@@ -15,12 +15,13 @@ module GrapeLogging
 
       def after
         stop_time
-        logger.info parameters(request, response)
+        logger.info parameters
+        ActiveSupport::Notifications.unsubscribe(@subscription) if @subscription
         nil
       end
 
       protected
-      def parameters(request, response)
+      def parameters
         {
             path: request.path,
             params: request.params.to_hash,


### PR DESCRIPTION
Middleware objects are temporary but ActiveSupport subscription is global.

Closure (created by middleware instance during single request)  survives further garbage  collections. Closure object reaches middleware instance, middleware instance reaches env-hash and response object (containing status code and body btw!) so they are all cannot be collected. There is a lot of leaking per-request memory that stays alive after the request is finished!