### PR TITLE
Unsubscribe notifier even when exception occurs

### DIFF
--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -16,8 +16,13 @@ module GrapeLogging
       def after
         stop_time
         logger.info parameters
-        ActiveSupport::Notifications.unsubscribe(@subscription) if @subscription
         nil
+      end
+
+      def call!(env)
+        super
+      ensure
+        ActiveSupport::Notifications.unsubscribe(@subscription) if @subscription
       end
 
       protected


### PR DESCRIPTION
In case of unhandled exception we should unsubscribe notifier anyway.