### PR TITLE
Make sure response status is always available

### DIFF
--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -33,7 +33,7 @@ module GrapeLogging
             method: request.request_method,
             total: total_runtime,
             db: @db_duration.round(2),
-            status: response.status
+            status: @app_response.status
         }
       end
 


### PR DESCRIPTION
Sometimes `response` is not what you think it is. `@app_response` is
always a proper Rack::Response object so it's safe to get its status.

See https://github.com/intridea/grape/issues/1059
