### PR TITLE
Thread safe middleware

### DIFF
--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -48,7 +48,7 @@ module GrapeLogging
           method: request.request_method,
           total: format_runtime(total_runtime),
           db: format_runtime(db_runtime),
-          status: response[0]
+          status: response.is_a?(Rack::Response) ? response.status : response[0]
         )
       end
 

--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -38,7 +38,7 @@ module GrapeLogging
         ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
           event = ActiveSupport::Notifications::Event.new(*args)
           increase_db_runtime(event.duration)
-        end if defined? ActiveRecord
+        end
       end
 
       def log(request, response, total_runtime)


### PR DESCRIPTION
Existing implementation is **NOT** thead-safe. 

That produces unexpected errors. See https://github.com/ruby-grape/grape/issues/1054 for details.

That's because `ActiveSupport::Notifications.subscribe/unsubscribe` is called in request cycle. And it's not thread-safe because of  `ActiveSupport::Notifications::Fanout`:

https://github.com/rails/rails/issues/5531#issuecomment-4664316

> Yes, the Fanout class is definitely not thread safe. But the subscribe / unsubscribe methods should be called on boot before any request threads are spun up.

New implementation should be thread-safe so that we can use grape with Puma, etc ...