### PR TITLE
Use AS:N in a threadsafe manner

### DIFF
--- a/lib/grape_logging.rb
+++ b/lib/grape_logging.rb
@@ -1,4 +1,5 @@
 require 'grape_logging/multi_io'
 require 'grape_logging/version'
 require 'grape_logging/formatters/default'
+require 'grape_logging/timings'
 require 'grape_logging/middleware/request_logger'

--- a/lib/grape_logging/timings.rb
+++ b/lib/grape_logging/timings.rb
@@ -1,0 +1,21 @@
+module GrapeLogging
+  module Timings
+    extend self
+
+    def db_runtime=(value)
+      Thread.current[:grape_db_runtime] = value
+    end
+
+    def db_runtime
+      Thread.current[:grape_db_runtime] ||= 0
+    end
+
+    def reset_db_runtime
+      self.db_runtime = 0
+    end
+
+    def append_db_runtime(event)
+      self.db_runtime += event.duration
+    end
+  end
+end


### PR DESCRIPTION
This PR sets up the AS:N subscription **once** during app init and then uses thread local variables to track the durations. Subscribing and unsubscribing on each request is not the right way to handle this.  I'd love to write some tests for this as well but for now this will have to do. 

I also threw in the `view` time a la Rails where they take the total time and subtract out the `db` time to get the `view` time.