### PR TITLE
Fix #29

### DIFF
--- a/lib/grape_logging/loggers/response.rb
+++ b/lib/grape_logging/loggers/response.rb
@@ -6,14 +6,22 @@ module GrapeLogging
       end
 
       private
+
       # In some cases, response.body is not parseable by JSON.
       # For example, if you POST on a PUT endpoint, response.body is egal to """".
       # It's strange but it's the Grape behavior...
       def serialized_response_body(response)
-        begin
-          response.body.map{ |body| JSON.parse(body.to_s) }
-        rescue => e
-          response.body
+
+        if response.respond_to?(:body)
+          # Rack responses
+          begin
+            response.body.map{ |body| JSON.parse(body.to_s) }
+          rescue # No reason to have "=> e" here when we don't use it..
+            response.body
+          end
+        else
+          # Error & Exception responses
+          response
         end
       end
     end

--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -9,6 +9,10 @@ module GrapeLogging
         GrapeLogging::Timings.append_db_runtime(event)
       end if defined?(ActiveRecord)
 
+      # Persist response status & response (body)
+      # to use int in parameters
+      attr_accessor :response_status, :response_body
+
       def initialize(app, options = {})
         super
 
@@ -23,34 +27,71 @@ module GrapeLogging
       def before
         reset_db_runtime
         start_time
-
         invoke_included_loggers(:before)
       end
 
-      def after
+      def after(status, response)
         stop_time
+
+        # Response status
+        @response_status = status
+        @response_body   = response
+
+        # Perform repotters
         @reporter.perform(collect_parameters)
+
+        # Invoke loggers
         invoke_included_loggers(:after)
         nil
       end
 
+      # Call stack and parse responses & status.
+      #
+      # @note Exceptions are logged as 500 status & re-raised.
       def call!(env)
-        super
+        @env = env
+
+        # Before hook
+        before
+
+        # Catch error
+        error = catch(:error) do
+          begin
+            @app_response = @app.call(@env)
+          rescue => e
+            # Log as 500 + message
+            after(500, e.message)
+
+            # Re-raise exception
+            raise e
+          end
+          nil
+        end
+
+        # Get status & response from app_response
+        # when no error occures.
+        if error
+          # Call with error & response
+          after(error[:status], error[:message])
+
+          # Throw again
+          throw(:error, error)
+        else
+          status, _, resp = *@app_response
+
+          # Call after hook properly
+          after(status, resp)
+        end
+
+        # Otherwise return original response
+        @app_response
       end
 
       protected
 
-      def response
-        begin
-          super
-        rescue
-          nil
-        end
-      end
-
       def parameters
         {
-          status: response.nil? ? 'fail' : response.status,
+          status: response_status,
           time: {
             total: total_runtime,
             db: db_runtime,
@@ -64,8 +105,9 @@ module GrapeLogging
       end
 
       private
+
       def request
-        @request ||= ::Rack::Request.new(env)
+        @request ||= ::Rack::Request.new(@env)
       end
 
       def total_runtime
@@ -95,7 +137,7 @@ module GrapeLogging
       def collect_parameters
         parameters.tap do |params|
           @included_loggers.each do |logger|
-            params.merge! logger.parameters(request, response) do |_, oldval, newval|
+            params.merge! logger.parameters(request, response_body) do |_, oldval, newval|
               oldval.respond_to?(:merge) ? oldval.merge(newval) : newval
             end
           end

--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -60,7 +60,7 @@ module GrapeLogging
             @app_response = @app.call(@env)
           rescue => e
             # Log as 500 + message
-            after(500, e.message)
+            after(e.respond_to?(:status) ? e.status : 500, e.message)
 
             # Re-raise exception
             raise e


### PR DESCRIPTION
Not sure about **serialized_response_body**, it is designed to always return a **Hash**? In case of Internal server error it returns string with error message...
