### PR TITLE
Fix already configured logger formatter override

### DIFF
--- a/lib/grape_logging/reporters/logger_reporter.rb
+++ b/lib/grape_logging/reporters/logger_reporter.rb
@@ -2,7 +2,9 @@ module Reporters
   class LoggerReporter
     def initialize(logger, formatter)
       @logger = logger || Logger.new(STDOUT)
-      @logger.formatter = formatter || GrapeLogging::Formatters::Default.new if @logger.respond_to?(:formatter=)
+      if @logger.respond_to?(:formatter=)
+        @logger.formatter = formatter || @logger.formatter || GrapeLogging::Formatters::Default.new
+      end
     end
 
     def perform(params)


### PR DESCRIPTION
I did discover slight inconsistency with logger configuration introduced in #23. If you have preconfigured logger with formatter, grape_logger will override it.

Here is an example.

```ruby

class App < Grape::API

  log_handler = ::Logger.new(STDOUT)
  log_handler.formatter = GrapeLogging::Formatters::Json.new

  use GrapeLogging::Middleware::RequestLogger, logger: log_handler

  get "/" { status 200 }
end

```

If you perform request to such an app, it will use `GrapeLogging::Formatters::Default` because of check in `LoggerReporter`.
