### PR TITLE
bump version to 1.8.1

### DIFF
--- a/lib/grape_logging/version.rb
+++ b/lib/grape_logging/version.rb
@@ -1,3 +1,3 @@
 module GrapeLogging
-  VERSION = '1.8.0'
+  VERSION = '1.8.1'
 end


### PR DESCRIPTION
The JSON formatter on the current release (v1.8.0) doesn't work for us. aserafin/grape_logging#52 fixes it (thanks @shuuuuun) but unfortunately it hasn't been released to rubygems yet so we have to pin it to the Github master, which is suboptimal. There's an open issue (aserafin/grape_logging#55) about this so it seems it's not a problem just for us.

So this is just a friendly nudge to try and help the release process and release that fix as 1.8.1 :) Do you mind taking it from here @aserafin ?

PS: Thanks for the great work on this gem :)