### PR TITLE
Use "insert 0" instead of "use" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In your api file (somewhere on the top)
 ```ruby
 require 'grape_logging'
 logger.formatter = GrapeLogging::Formatters::Default.new
-use GrapeLogging::Middleware::RequestLogger, { logger: logger }
+insert 0, GrapeLogging::Middleware::RequestLogger, { logger: logger }
 ```
 
 **ProTip:** If your logger doesn't support setting formatter you can remove this line - it's optional
@@ -114,7 +114,7 @@ end
 You can change the formatter like so
 ```ruby
 class MyAPI < Grape::API
-  use GrapeLogging::Middleware::RequestLogger, logger: logger, formatter: MyFormatter.new
+  insert 0, GrapeLogging::Middleware::RequestLogger, logger: logger, formatter: MyFormatter.new
 end
 ```
 
@@ -125,7 +125,7 @@ If you prefer some other format I strongly encourage you to do pull request with
 You can include logging of other parts of the request / response cycle by including subclasses of `GrapeLogging::Loggers::Base`
 ```ruby
 class MyAPI < Grape::API
-  use GrapeLogging::Middleware::RequestLogger,
+  insert 0, GrapeLogging::Middleware::RequestLogger,
     logger: logger,
     include: [ GrapeLogging::Loggers::Response.new,
                GrapeLogging::Loggers::FilterParameters.new,
@@ -158,7 +158,7 @@ You can control the level used to log. The default is `info`.
 
 ```ruby
 class MyAPI < Grape::API
-  use GrapeLogging::Middleware::RequestLogger,
+  insert 0, GrapeLogging::Middleware::RequestLogger,
     logger: logger,
     log_level: 'debug'
 end
@@ -170,7 +170,7 @@ You can choose to not pass the logger to ```grape_logging``` but instead send lo
 First, config ```grape_logging```, like that:
 ```ruby
 class MyAPI < Grape::API
-  use GrapeLogging::Middleware::RequestLogger,
+  insert 0, GrapeLogging::Middleware::RequestLogger,
     instrumentation_key: 'grape_key',
     include: [ GrapeLogging::Loggers::Response.new,
                GrapeLogging::Loggers::FilterParameters.new ]


### PR DESCRIPTION
The status code won't be correct when it is changed in `rescue_from` block, so use "insert 0" instead of "use" in README.

I describe more details below.

## Before

```ruby
class MyApi < Grape::API
  use GrapeLogging::Middleware::RequestLogger

  rescue_from :all do |e|
    error!('bad request', 400)
  end

  get do
    raise MyError, 'error'
  end
end
```

```
% curl -i localhost:3000
HTTP/1.1 400 Bad Request
Content-Type: text/plain
Cache-Control: no-cache
X-Request-Id: 8e5d48cf-c752-4e45-aaa0-ef9c2ac197ef
X-Runtime: 0.030238
Content-Length: 11

bad request
```

The server log is like below:

```
[2019-05-02 00:29:25 +0900] INFO -- 500 -- db=0 total=4.98 view=4.98 -- GET / host=localhost params={}
```

As you can see, the status code in the log is 500 in spite of the fact that the actual status code is 400.

## After

```ruby
class MyApi < Grape::API
  insert 0, GrapeLogging::Middleware::RequestLogger

  rescue_from :all do |e|
    error!('bad request', 400)
  end

  get do
    raise MyError, 'error'
  end
end
```

```
% curl -i localhost:3000
HTTP/1.1 400 Bad Request
Content-Type: text/plain
Cache-Control: no-cache
X-Request-Id: ba717065-72f3-4de1-8b6d-21b6258714bc
X-Runtime: 0.016160
Content-Length: 11

bad request
```

The server log is like below:

```
[2019-05-02 00:30:33 +0900] INFO -- 400 -- db=0 total=1.46 view=1.46 -- GET / host=localhost params={}
```
