### PR TITLE
Change from deprecated ActionDispatch::Http::ParameterFilter to ActiveSupport::ParameterFilter for Rails 6

### DIFF
--- a/lib/grape_logging/util/parameter_filter.rb
+++ b/lib/grape_logging/util/parameter_filter.rb
@@ -1,5 +1,5 @@
 if defined?(::Rails.application)
-  class ParameterFilter < ActionDispatch::Http::ParameterFilter
+  class ParameterFilter < ActiveSupport::ParameterFilter
     def initialize(_replacement, filter_parameters)
       super(filter_parameters)
     end


### PR DESCRIPTION
Related to this Rails 6 deprecation warning: `ActionDispatch::Http::ParameterFilter is deprecated and will be removed from Rails 6.1. Use ActiveSupport::ParameterFilter instead.`