### PR TITLE
fix view time precise issue

### DIFF
--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -115,7 +115,7 @@ module GrapeLogging
       end
 
       def view_runtime
-        total_runtime - db_runtime
+        (total_runtime - db_runtime).round(2)
       end
 
       def db_runtime


### PR DESCRIPTION
I used `grape_logging` in my app, and found view_time is display precise issue, please refer below:
```bash
[2020-04-04 20:33:44 +0800] INFO -- 200 -- db=2.57 total=85.69 view=83.12 -- POST /logins host=127.0.0.1 params={"name"=>"john"}
[2020-04-04 20:33:45 +0800] INFO -- 200 -- db=0.13 total=14.95 view=14.819999999999999 -- POST /logins host=127.0.0.1 params={"name"=>"john"}
[2020-04-04 20:33:45 +0800] INFO -- 200 -- db=0.13 total=14.2 view=14.069999999999999 -- POST /logins host=127.0.0.1 params={"name"=>"john"}
[2020-04-04 20:33:45 +0800] INFO -- 200 -- db=0.14 total=14.73 view=14.59 -- POST /logins host=127.0.0.1 params={"name"=>"john"}
[2020-04-04 20:33:45 +0800] INFO -- 200 -- db=0.12 total=14.11 view=13.99 -- POST /logins host=127.0.0.1 params={"name"=>"john"}
[2020-04-04 20:33:45 +0800] INFO -- 200 -- db=0.14 total=22.04 view=21.9 -- POST /logins host=127.0.0.1 params={"name"=>"john"}
[2020-04-04 20:33:45 +0800] INFO -- 200 -- db=0.12 total=14.16 view=14.040000000000001 -- POST /logins host=127.0.0.1 params={"name"=>"john"}
```