### PR TITLE
Bugfix: Require ActiveSupport::ParameterFilter before inheriting from it

### DIFF
--- a/lib/grape_logging/util/parameter_filter.rb
+++ b/lib/grape_logging/util/parameter_filter.rb
@@ -6,6 +6,8 @@ if defined?(::Rails.application)
       end
     end
   else
+    require "active_support/parameter_filter"
+
     class ParameterFilter < ActiveSupport::ParameterFilter
       def initialize(_replacement, filter_parameters)
         super(filter_parameters)


### PR DESCRIPTION
Addresses #66. It is not guaranteed that all of `ActiveSupport` will be loaded at the time this gem gets loaded, and indeed in smaller builds, that is exactly what is causing the bug. I couldn't test this in an automated way without adding a dependency on Rails, but manually adding this fixed my issue locally. Additionally, adding this to an application where the setup already worked merely resulted in the `require` call returning `false` and the application loading correctly.