### PR TITLE
feat: change time hash name to time_consumed

### DIFF
--- a/lib/grape_logging/formatters/default.rb
+++ b/lib/grape_logging/formatters/default.rb
@@ -11,13 +11,14 @@ module GrapeLogging
         elsif data.is_a?(Exception)
           format_exception(data)
         elsif data.is_a?(Hash)
-          "#{data.delete(:status)} -- #{format_hash(data.delete(:time))} -- #{data.delete(:method)} #{data.delete(:path)} #{format_hash(data)}"
+          "#{data.delete(:status)} -- #{format_hash(data.delete(:time_consumed))} -- #{data.delete(:method)} #{data.delete(:path)} #{format_hash(data)}"
         else
           data.inspect
         end
       end
 
       private
+
       def format_hash(hash)
         hash.keys.sort.map { |key| "#{key}=#{hash[key]}" }.join(' ')
       end

--- a/lib/grape_logging/formatters/lograge.rb
+++ b/lib/grape_logging/formatters/lograge.rb
@@ -2,7 +2,7 @@ module GrapeLogging
   module Formatters
     class Lograge
       def call(severity, datetime, _, data)
-        time = data.delete :time
+        time = data.delete :time_consumed
         attributes = {
           severity: severity,
           duration: time[:total],

--- a/lib/grape_logging/formatters/rails.rb
+++ b/lib/grape_logging/formatters/rails.rb
@@ -3,7 +3,6 @@ require 'rack/utils'
 module GrapeLogging
   module Formatters
     class Rails
-
       def call(severity, datetime, _, data)
         if data.is_a?(String)
           "#{severity[0..0]} [#{datetime}] #{severity} -- : #{data}\n"
@@ -24,7 +23,7 @@ module GrapeLogging
         [
           "#{exception.message} (#{exception.class})",
           backtrace_array.join("\n")
-        ].reject{|line| line == ""}.join("\n")
+        ].reject { |line| line == '' }.join("\n")
       end
 
       def format_hash(hash)
@@ -32,14 +31,14 @@ module GrapeLogging
         # Completed 200 OK in 958ms (Views: 951.1ms | ActiveRecord: 3.8ms)
         # See: actionpack/lib/action_controller/log_subscriber.rb
 
-        message = ""
+        message = ''
         additions = []
         status = hash.delete(:status)
         params = hash.delete(:params)
 
-        total_time = hash[:time] && hash[:time][:total] && hash[:time][:total].round(2)
-        view_time  = hash[:time] && hash[:time][:view]  && hash[:time][:view].round(2)
-        db_time    = hash[:time] && hash[:time][:db]    && hash[:time][:db].round(2)
+        total_time = hash[:time_consumed] && hash[:time_consumed][:total] && hash[:time_consumed][:total].round(2)
+        view_time  = hash[:time_consumed] && hash[:time_consumed][:view]  && hash[:time_consumed][:view].round(2)
+        db_time    = hash[:time_consumed] && hash[:time_consumed][:db]    && hash[:time_consumed][:db].round(2)
 
         additions << "Views: #{view_time}ms" if view_time
         additions << "DB: #{db_time}ms"      if db_time
@@ -47,13 +46,12 @@ module GrapeLogging
         message << "  Parameters: #{params.inspect}\n" if params
 
         message << "Completed #{status} #{::Rack::Utils::HTTP_STATUS_CODES[status]} in #{total_time}ms"
-        message << " (#{additions.join(" | ".freeze)})" if additions.size > 0
+        message << " (#{additions.join(' | '.freeze)})" if additions.size > 0
         message << "\n"
         message << "\n" if defined?(::Rails.env) && ::Rails.env.development?
 
         message
       end
-
     end
   end
 end

--- a/spec/lib/grape_logging/formatters/rails_spec.rb
+++ b/spec/lib/grape_logging/formatters/rails_spec.rb
@@ -2,23 +2,23 @@ require 'spec_helper'
 
 describe GrapeLogging::Formatters::Rails do
   let(:formatter) { described_class.new }
-  let(:severity) { "INFO" }
+  let(:severity) { 'INFO' }
   let(:datetime) { Time.new('2018', '03', '02', '10', '35', '04', '+13:00') }
 
   let(:exception_data) { ArgumentError.new('Message') }
-  let(:hash_data) {
+  let(:hash_data) do
     {
       status: 200,
-      time: {
+      time_consumed: {
         total: 272.4,
         db: 40.63,
         view: 231.76999999999998
       },
-      method: "GET",
-      path: "/api/endpoint",
-      host: "localhost"
+      method: 'GET',
+      path: '/api/endpoint',
+      host: 'localhost'
     }
-  }
+  end
 
   describe '#call' do
     context 'string data' do
@@ -31,12 +31,12 @@ describe GrapeLogging::Formatters::Rails do
 
     context 'exception data' do
       it 'returns a string with a backtrace' do
-        exception_data.set_backtrace(caller)
+        exception_data.set_backtrace(caller(0))
 
         message = formatter.call(severity, datetime, nil, exception_data)
         lines = message.split("\n")
 
-        expect(lines[0]).to eq "I [2018-03-02 10:35:04 +1300] INFO -- : Message (ArgumentError)"
+        expect(lines[0]).to eq 'I [2018-03-02 10:35:04 +1300] INFO -- : Message (ArgumentError)'
         expect(lines[1]).to include 'grape_logging'
         expect(lines.size).to be > 1
       end
@@ -52,9 +52,9 @@ describe GrapeLogging::Formatters::Rails do
       it 'includes params if included (from GrapeLogging::Loggers::FilterParameters)' do
         hash_data.merge!(
           params: {
-            "some_param" => {
-              value_1: "123",
-              value_2: "456"
+            'some_param' => {
+              value_1: '123',
+              value_2: '456'
             }
           }
         )
@@ -63,11 +63,11 @@ describe GrapeLogging::Formatters::Rails do
         lines = message.split("\n")
 
         expect(lines.first).to eq '  Parameters: {"some_param"=>{:value_1=>"123", :value_2=>"456"}}'
-        expect(lines.last).to eq "Completed 200 OK in 272.4ms (Views: 231.77ms | DB: 40.63ms)"
+        expect(lines.last).to eq 'Completed 200 OK in 272.4ms (Views: 231.77ms | DB: 40.63ms)'
       end
     end
 
-    context "unhandled data" do
+    context 'unhandled data' do
       it 'returns the #inspect string representation' do
         message = formatter.call(severity, datetime, nil, [1, 2, 3])
 
@@ -75,5 +75,4 @@ describe GrapeLogging::Formatters::Rails do
       end
     end
   end
-
 end

--- a/spec/lib/grape_logging/middleware/request_logger_spec.rb
+++ b/spec/lib/grape_logging/middleware/request_logger_spec.rb
@@ -3,10 +3,10 @@ require 'rack'
 
 describe GrapeLogging::Middleware::RequestLogger do
   let(:subject) { request.send(request_method, path) }
-  let(:app) { proc{ [status, {} , ['response body']] } }
+  let(:app) { proc { [status, {}, ['response body']] } }
   let(:stack) { described_class.new app, options }
   let(:request) { Rack::MockRequest.new(stack) }
-  let(:options) { {include: [], logger: logger} }
+  let(:options) { { include: [], logger: logger } }
   let(:logger) { double('logger') }
   let(:path) { '/' }
   let(:request_method) { 'get' }
@@ -18,10 +18,10 @@ describe GrapeLogging::Middleware::RequestLogger do
       expect(arguments[:method]).to eq 'GET'
       expect(arguments[:params]).to be_empty
       expect(arguments[:host]).to eq 'example.org'
-      expect(arguments).to have_key :time
-      expect(arguments[:time]).to have_key :total
-      expect(arguments[:time]).to have_key :db
-      expect(arguments[:time]).to have_key :view
+      expect(arguments).to have_key :time_consumed
+      expect(arguments[:time_consumed]).to have_key :total
+      expect(arguments[:time_consumed]).to have_key :db
+      expect(arguments[:time_consumed]).to have_key :view
     end
     subject
   end
@@ -49,7 +49,7 @@ describe GrapeLogging::Middleware::RequestLogger do
   end
 
   context 'with a nil response' do
-    let(:app) { proc{ [500, {} , nil] } }
+    let(:app) { proc { [500, {}, nil] } }
     it 'should log "fail" instead of a status' do
       expect(Rack::MockResponse).to receive(:new) { nil }
       expect(logger).to receive('info') do |arguments|
@@ -64,7 +64,7 @@ describe GrapeLogging::Middleware::RequestLogger do
       options[:include] << GrapeLogging::Loggers::RequestHeaders.new
       options[:include] << GrapeLogging::Loggers::ClientEnv.new
       options[:include] << GrapeLogging::Loggers::Response.new
-      options[:include] << GrapeLogging::Loggers::FilterParameters.new(["replace_me"])
+      options[:include] << GrapeLogging::Loggers::FilterParameters.new(['replace_me'])
     end
 
     %w[get put post delete options head patch].each do |the_method|
@@ -84,9 +84,9 @@ describe GrapeLogging::Middleware::RequestLogger do
     it 'should filter parameters in the log' do
       expect(logger).to receive('info') do |arguments|
         expect(arguments[:params]).to eq(
-          "replace_me" => '[FILTERED]',
-          "replace_me_too" => '[FILTERED]',
-          "cant_touch_this" => 'should see'
+          'replace_me' => '[FILTERED]',
+          'replace_me_too' => '[FILTERED]',
+          'cant_touch_this' => 'should see'
         )
       end
       parameters = {


### PR DESCRIPTION
Some loggers (like Ougai) use "time" provided in data as
the time to be used for the log line. This PR replaces `time`
with `time_consumed`.