### PR TITLE
Update how grape logging middleware should be placed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Or install it yourself as:
 
 ## Basic Usage
 
-In your api file (somewhere on the top)
+In your api file (somewhere on the top), insert grape logging middleware before grape error middleware. This is important due to the behaviour of `lib/grape/middleware/error.rb`, which manipulates the status of the response when there is an error. 
 
 ```ruby
 require 'grape_logging'
 logger.formatter = GrapeLogging::Formatters::Default.new
-use GrapeLogging::Middleware::RequestLogger, { logger: logger }
+insert_before Grape::Middleware::Error, GrapeLogging::Middleware::RequestLogger, { logger: logger }
 ```
 
 **ProTip:** If your logger doesn't support setting formatter you can remove this line - it's optional


### PR DESCRIPTION
At my company we use grape logging to perform rich logging of our grape API endpoints. 

However, there were casual cases where I can see in our monitoring system, there is no response with status `500`, but a bunch of these are being printed in the log.

That leads me to finding out what caused this and it seems to be the case (not sure if niche) that grape_logging is being required after Grape's default Error middleware. 

Brief description in call stack: (notice the number)
<img width="1263" alt="image" src="https://user-images.githubusercontent.com/15828926/120179609-0356af80-c235-11eb-95d9-63c25c322481.png">
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/15828926/120179619-081b6380-c235-11eb-8fc9-e30d1a9e9160.png">



This leads to the case where an app has an `error` with a status other than 500, this https://github.com/ruby-grape/grape/blob/87cb0052b874b40824faeae2cfbd73c28da1d69b/lib/grape/middleware/error.rb#L63 line runs , and it runs after this line https://github.com/aserafin/grape_logging/blob/8afa893a698d2d9c17e72dadcae77c2f3551cde2/lib/grape_logging/middleware/request_logger.rb#L63 so the status that this middleware is logging is always 500 for all cases 

A simple fix would be enhancing the doc, while more advanced one should be automatically checking the required stack to see if our logging middleware comes before error middleware. 

