### PR TITLE
Replaced all 'use' examples in README.md with 'insert_before'

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ end
 You can change the formatter like so
 ```ruby
 class MyAPI < Grape::API
-  use GrapeLogging::Middleware::RequestLogger, logger: logger, formatter: MyFormatter.new
+  insert_before Grape::Middleware::Error, GrapeLogging::Middleware::RequestLogger, logger: logger, formatter: MyFormatter.new
 end
 ```
 
@@ -125,7 +125,8 @@ If you prefer some other format I strongly encourage you to do pull request with
 You can include logging of other parts of the request / response cycle by including subclasses of `GrapeLogging::Loggers::Base`
 ```ruby
 class MyAPI < Grape::API
-  use GrapeLogging::Middleware::RequestLogger,
+  insert_before Grape::Middleware::Error,
+    GrapeLogging::Middleware::RequestLogger,
     logger: logger,
     include: [ GrapeLogging::Loggers::Response.new,
                GrapeLogging::Loggers::FilterParameters.new,
@@ -158,7 +159,8 @@ You can control the level used to log. The default is `info`.
 
 ```ruby
 class MyAPI < Grape::API
-  use GrapeLogging::Middleware::RequestLogger,
+  insert_before Grape::Middleware::Error, 
+    GrapeLogging::Middleware::RequestLogger,
     logger: logger,
     log_level: 'debug'
 end
@@ -170,7 +172,8 @@ You can choose to not pass the logger to ```grape_logging``` but instead send lo
 First, config ```grape_logging```, like that:
 ```ruby
 class MyAPI < Grape::API
-  use GrapeLogging::Middleware::RequestLogger,
+  insert_before Grape::Middleware::Error,
+    GrapeLogging::Middleware::RequestLogger,
     instrumentation_key: 'grape_key',
     include: [ GrapeLogging::Loggers::Response.new,
                GrapeLogging::Loggers::FilterParameters.new ]


### PR DESCRIPTION
Finalizing the partial changes introduced in #74 and reported in #45. All `use` example statements got replaced in the README.md

This should prevent confusions while reading the README and also prevent users running in to the #45 issue.