### PR TITLE
Update gemspec dependencies and specs

### DIFF
--- a/grape_logging.gemspec
+++ b/grape_logging.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Out of the box request logging for Grape!}
   spec.description   = %q{This gem provides simple request logging for Grape with just few lines of code you have to put in your project! In return you will get response codes, paths, parameters and more!}
-  spec.homepage      = 'http://github.com/aserafin/grape_logging'
+  spec.homepage      = 'https://github.com/araccaine/grape_logging'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'grape'
   spec.add_dependency 'rack'
 
-  spec.add_development_dependency 'bundler', '~> 1.8'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.5'
-  spec.add_development_dependency 'pry-byebug', '~> 3.4.2'
+  spec.add_development_dependency 'bundler', '~> 2.4'
+  spec.add_development_dependency 'rake', '~> 11.3'
+  spec.add_development_dependency 'rspec', '~> 3.13'
+  spec.add_development_dependency 'pry-byebug', '~> 3.10'
 end

--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -1,3 +1,4 @@
+require 'grape/middleware/helpers'
 require 'grape/middleware/base'
 
 module GrapeLogging


### PR DESCRIPTION
## What

- Updates dependencies for development
- Fixes `rspec` not running any tests due to `uninitialized constant Grape::Middleware::Base::Helpers` error (see https://github.com/ruby-grape/grape/issues/1939 and this commit: https://github.com/luong-komorebi/grape_logging/commit/6196c6ba4fcdcebfba67559cc62b707d1dc5c8b9)

## Notes

Spec `GrapeLogging::Formatters::Rails#call exception data returns a string with a backtrace` (in spec/lib/grape_logging/formatters/rails_spec.rb:32) still fails:

```
expected "\t/home/user/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:263:in `instance_exec'" to include "grape_logging"

  0) GrapeLogging::Formatters::Rails#call exception data returns a string with a backtrace
     Failure/Error: expect(lines[1]).to include 'grape_logging'
       expected "\t/home/user/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.13.0/lib/rspec/core/example.rb:263:in `instance_exec'" to include "grape_logging"
     # ./spec/lib/grape_logging/formatters/rails_spec.rb:40:in `block (4 levels) in <top (required)>'
``` 