### PR TITLE
[Misc] Nitpick typoes

### DIFF
--- a/lib/grape_logging/loggers/response.rb
+++ b/lib/grape_logging/loggers/response.rb
@@ -9,7 +9,7 @@ module GrapeLogging
 
       # In some cases, response.body is not parseable by JSON.
       # For example, if you POST on a PUT endpoint, response.body is egal to """".
-      # It's strange but it's the Grape behavior...
+      # It's strange, but it's the Grape behavior...
       def serialized_response_body(response)
 
         if response.respond_to?(:body)

--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -37,7 +37,7 @@ module GrapeLogging
         @response_status = status
         @response_body   = response
 
-        # Perform repotters
+        # Perform reporters
         @reporter.perform(collect_parameters)
 
         # Invoke loggers
@@ -69,7 +69,7 @@ module GrapeLogging
         end
 
         # Get status & response from app_response
-        # when no error occures.
+        # when no error occurs.
         if error
           # Call with error & response
           after(error[:status], error[:message])

--- a/spec/lib/grape_logging/loggers/request_headers_spec.rb
+++ b/spec/lib/grape_logging/loggers/request_headers_spec.rb
@@ -6,7 +6,7 @@ describe GrapeLogging::Loggers::RequestHeaders do
     OpenStruct.new(env: {HTTP_REFERER: 'http://example.com', HTTP_ACCEPT: 'text/plain'})
   end
 
-  let(:mock_request_with_unhandle_headers) do
+  let(:mock_request_with_unhandled_headers) do
     OpenStruct.new(env: {
       HTTP_REFERER: 'http://example.com',
       "PATH_INFO"=>"/api/v1/users"
@@ -27,7 +27,7 @@ describe GrapeLogging::Loggers::RequestHeaders do
   end
 
   it 'only handle things which start with HTTP_' do
-    expect(subject.parameters(mock_request_with_unhandle_headers, nil)).to eq({
+    expect(subject.parameters(mock_request_with_unhandled_headers, nil)).to eq({
       headers: {'Referer' => 'http://example.com' }
     })
   end

--- a/spec/lib/grape_logging/middleware/request_logger_spec.rb
+++ b/spec/lib/grape_logging/middleware/request_logger_spec.rb
@@ -27,7 +27,7 @@ describe GrapeLogging::Middleware::RequestLogger do
   end
 
   [301, 404, 500].each do |the_status|
-    context "when the respnse status is #{the_status}" do
+    context "when the response status is #{the_status}" do
       let(:status) { the_status }
       it 'should log the correct status code' do
         expect(logger).to receive('info') do |arguments|


### PR DESCRIPTION
Bunch of nitpick bits when having a read through the repo, shouldn't conflict with `lib/grape_logging/loggers/response.rb` in #80 