### PR TITLE
Add ActionDispatch request ID to logger arguments hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [2.0.1] - Unreleased
 
-### Changed or Fixed or Added
-* Your contribution here.
+## Added
+- [#91](https://github.com/aserafin/grape_logging/pull/91) Add ActionDispatch request ID to logger arguments hash as `:request_id` - [@samsonjs](https://github.com/samsonjs).
+
+- Your contribution here.
 
 [2.0.1]: https://github.com/aserafin/grape_logging/compare/v2.0.0...master
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
 # Changelog
 
-## [2.0.1] - Unreleased
+## [2.1.0] - 2025-07-09
 
 ## Added
 - [#91](https://github.com/aserafin/grape_logging/pull/91) Add ActionDispatch request ID to logger arguments hash as `:request_id` - [@samsonjs](https://github.com/samsonjs).
 
-- Your contribution here.
-
-[2.0.1]: https://github.com/aserafin/grape_logging/compare/v2.0.0...master
+[2.1.0]: https://github.com/aserafin/grape_logging/compare/v2.0.0...v2.1.0
 
 ## [2.0.0] - 2025-07-09
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -99,7 +99,7 @@ Add the next release to [CHANGELOG.md](https://github.com/aserafin/grape_logging
 ## [Next Release]
 
 ### Changed or Fixed or Added
-* Your contribution here.
+- Your contribution here.
 ```
 
 Commit your changes.

--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -98,7 +98,8 @@ module GrapeLogging
           method: request.request_method,
           path: request.path,
           params: request.params,
-          host: request.host
+          host: request.host,
+          request_id: env['action_dispatch.request_id'],
         }
       end
 

--- a/spec/lib/grape_logging/middleware/request_logger_spec.rb
+++ b/spec/lib/grape_logging/middleware/request_logger_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 require 'rack'
 
 describe GrapeLogging::Middleware::RequestLogger do
-  let(:subject) { request.send(request_method, path) }
+  let(:env) { { 'action_dispatch.request_id' => 'request-abc123' } }
+  let(:subject) { request.send(request_method, path, env) }
   let(:app) { proc{ [status, {} , ['response body']] } }
   let(:stack) { described_class.new app, options }
   let(:request) { Rack::MockRequest.new(stack) }
@@ -18,6 +19,7 @@ describe GrapeLogging::Middleware::RequestLogger do
       expect(arguments[:method]).to eq 'GET'
       expect(arguments[:params]).to be_empty
       expect(arguments[:host]).to eq 'example.org'
+      expect(arguments[:request_id]).to eq 'request-abc123'
       expect(arguments).to have_key :time
       expect(arguments[:time]).to have_key :total
       expect(arguments[:time]).to have_key :db


### PR DESCRIPTION
This is a non-breaking change that I need to test out version 2 in production at 1SE. Will go out immediately in version 2.1.0 since it adds a new feature.