### PR TITLE
Handle symbol param keys during filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Changelog
 
-## [2.1.1] - Unreleased
+## [2.1.1] - 2025-07-09
 
-## Added or Changed or Fixed
-- Your contribution here.
+### Fixed
+- [#92](https://github.com/aserafin/grape_logging/pull/92) Handle symbol param keys during filtering - [@samsonjs](https://github.com/samsonjs).
 
-[2.1.1]: https://github.com/aserafin/grape_logging/compare/v2.1.0...master
+[2.1.1]: https://github.com/aserafin/grape_logging/compare/v2.1.0...v2.1.1
 
 ## [2.1.0] - 2025-07-09
 
-## Added
+### Added
 - [#91](https://github.com/aserafin/grape_logging/pull/91) Add ActionDispatch request ID to logger arguments hash as `:request_id` - [@samsonjs](https://github.com/samsonjs).
 
 [2.1.0]: https://github.com/aserafin/grape_logging/compare/v2.0.0...v2.1.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ Check that the last build succeeded in [GitHub Actions](https://github.com/asera
 
 ### Update Changelog
 
-Change "Next Release" in [CHANGELOG.md](https://github.com/aserafin/grape_logging/blob/master/CHANGELOG.md) to the new version and date:
+Change "Unreleased" in [CHANGELOG.md](https://github.com/aserafin/grape_logging/blob/master/CHANGELOG.md) to the new version and date:
 
 ```
 ## [1.8.5] - 2024-06-28
@@ -96,10 +96,12 @@ end
 Add the next release to [CHANGELOG.md](https://github.com/aserafin/grape_logging/blob/master/CHANGELOG.md).
 
 ```
-## [Next Release]
+## [1.8.6] - Unreleased
 
 ### Changed or Fixed or Added
 - Your contribution here.
+
+[1.8.6]: https://github.com/aserafin/grape_logging/compare/v1.8.5...master
 ```
 
 Commit your changes.

--- a/lib/grape_logging/loggers/filter_parameters.rb
+++ b/lib/grape_logging/loggers/filter_parameters.rb
@@ -37,14 +37,16 @@ module GrapeLogging
 
       def build_encoding_map(parameters)
         parameters.each_with_object({}) do |(k, v), h|
-          h[k.dup.force_encoding(Encoding::ASCII_8BIT)] = [k.encoding, v.is_a?(Hash) ? build_encoding_map(v) : nil]
+          key_str = k.to_s
+          h[key_str.dup.force_encoding(Encoding::ASCII_8BIT)] = [key_str.encoding, v.is_a?(Hash) ? build_encoding_map(v) : nil]
         end
       end
 
       def transform_key_encoding(parameters, encoding_map)
         parameters.each_with_object({}) do |(k, v), h|
-          encoding, children_encoding_map = encoding_map[k]
-          h[k.dup.force_encoding(encoding)] = v.is_a?(Hash) ? transform_key_encoding(v, children_encoding_map) : v
+          key_str = k.to_s
+          encoding, children_encoding_map = encoding_map[key_str]
+          h[key_str.dup.force_encoding(encoding)] = v.is_a?(Hash) ? transform_key_encoding(v, children_encoding_map) : v
         end
       end
     end

--- a/spec/lib/grape_logging/loggers/filter_parameters_spec.rb
+++ b/spec/lib/grape_logging/loggers/filter_parameters_spec.rb
@@ -78,4 +78,14 @@ describe GrapeLogging::Loggers::FilterParameters do
     let(:replacement) { 'CUSTOM_REPLACEMENT' }
     it_behaves_like 'filtering'
   end
+
+  context 'with symbol keys, which occur during automated testing' do
+    let(:mock_request) { OpenStruct.new(params: { sneaky_symbol: 'hey!' }) }
+
+    it 'converts keys to strings' do
+      expect(subject.parameters(mock_request, nil)).to eq(params: {
+        'sneaky_symbol' => 'hey!',
+      })
+    end
+  end
 end


### PR DESCRIPTION
In testing these keys can be symbols, so when we're working with encodings make sure we have strings before trying to force any encodings on keys.