### PR TITLE
Add support for Grape 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [2.1.2] - Unreleased
 
-### Changed or Fixed or Added
-- Your contribution here.
+### Changed
+- [#93](https://github.com/aserafin/grape_logging/pull/93) RequestLogger middleware to handle Grape 2.4 breaking change - [@devsigner](https://github.com/devsigner) and [@samsonjs](https://github.com/samsonjs).
 
 [2.1.2]: https://github.com/aserafin/grape_logging/compare/v2.1.1...master
 

--- a/grape_logging.gemspec
+++ b/grape_logging.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'grape', '< 2.4.0'
+  spec.add_dependency 'grape', '>= 2.4.0'
   spec.add_dependency 'rack'
 
   spec.add_development_dependency 'rake', '~> 13.3'

--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -15,7 +15,7 @@ module GrapeLogging
       attr_accessor :response_status, :response_body
 
       def initialize(app, options = {})
-        super
+        super(app, **options)
 
         @included_loggers = @options[:include] || []
         @reporter =

--- a/lib/grape_logging/middleware/request_logger.rb
+++ b/lib/grape_logging/middleware/request_logger.rb
@@ -14,8 +14,8 @@ module GrapeLogging
       # to use int in parameters
       attr_accessor :response_status, :response_body
 
-      def initialize(app, options = {})
-        super(app, **options)
+      def initialize(app, **options)
+        super
 
         @included_loggers = @options[:include] || []
         @reporter =

--- a/spec/lib/grape_logging/middleware/request_logger_spec.rb
+++ b/spec/lib/grape_logging/middleware/request_logger_spec.rb
@@ -5,7 +5,7 @@ describe GrapeLogging::Middleware::RequestLogger do
   let(:env) { { 'action_dispatch.request_id' => 'request-abc123' } }
   let(:subject) { request.send(request_method, path, env) }
   let(:app) { proc { [status, {}, ['response body']] } }
-  let(:stack) { described_class.new app, options }
+  let(:stack) { described_class.new app, **options }
   let(:request) { Rack::MockRequest.new(stack) }
   let(:options) { { include: [], logger: logger } }
   let(:logger) { double('logger') }


### PR DESCRIPTION
`RequestLogger` middleware has to match Grape's new base class initializer signature. Will be released in 3.0 shortly.

Obsoletes #83 and closes #82